### PR TITLE
Fix issue #72 - log location

### DIFF
--- a/development-example.ini
+++ b/development-example.ini
@@ -42,6 +42,8 @@ smtp_port = 0
 #  Logging settings
 #
 log_level = INFO
+# Change log_filename to be the location of where you want your log saved.  By default it will be saved
+# in your project root, which may not work if you don't have the correct permissions to save files in that directory
 log_filename = ./nflpool_log.txt
 
 [server:main]


### PR DESCRIPTION
Update development-example.ini with code comments on where to save
the log.  If using something like systemd to start Pyramid, you may
not have the right permissions to save the log in the default location
or may want to change where it's saved.